### PR TITLE
Fixed weird overflow bug

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,63 +1,66 @@
 {
-    "versionLabel": "1.2",
-    "uuid": "0A477443-FB0A-4039-967F-7608276EEC45",
     "appKeys": {
-	    "currency": 1,
-	    "exchange": 2,
-	    "ask": 3,
-	    "bid": 4,
-	    "last": 5,
-	    "invert": 6
-	},
-    "longName": "BitWatcher",
-    "versionCode": 3,
-    "shortName": "BitWatcher",
-    "companyName": "kabili207",
-    "capabilities": [ "configurable" ],
-    "watchapp": {
-        "watchface": true
+        "ask": 3,
+        "bid": 4,
+        "currency": 1,
+        "exchange": 2,
+        "invert": 6,
+        "last": 5
     },
+    "capabilities": [
+        "configurable"
+    ],
+    "companyName": "kabili207",
+    "longName": "BitWatcher",
+    "projectType": "native",
     "resources": {
         "media": [
             {
-                "menuIcon": true,
-                "type": "png",
-                "name": "IMAGE_MENU_ICON",
-                "file": "images/menu_icon_bitwallet.png"
+                "file": "fonts/Diavlo_BOOK_II_37.ttf",
+                "name": "FONT_DIAVLO_15",
+                "type": "font"
             },
             {
-                "type": "font",
-                "name": "FONT_DIAVLO_LIGHT_15",
-                "file": "fonts/Diavlo_LIGHT_II_37.ttf"
+                "characterRegex": "[0-9:. +-]",
+                "file": "fonts/Diavlo_MEDIUM_II_37.ttf",
+                "name": "FONT_DIAVLO_MEDIUM_29",
+                "type": "font"
+            },
+            {
+                "file": "fonts/Diavlo_MEDIUM_II_37.ttf",
+                "name": "FONT_DIAVLO_MEDIUM_19",
+                "type": "font"
+            },
+            {
+                "characterRegex": "[0-9:. +-]",
+                "file": "fonts/Diavlo_MEDIUM_II_37.ttf",
+                "name": "FONT_DIAVLO_MEDIUM_39",
+                "type": "font"
             },
             {
                 "characterRegex": "[0-9:.]",
-                "type": "font",
-                "name": "FONT_DIAVLO_HEAVY_45",
-                "file": "fonts/Diavlo_BLACK_II_37.ttf"
+                "file": "fonts/Diavlo_BLACK_II_37.ttf",
+                "name": "FONT_DIAVLO_HEAVY_44",
+                "type": "font"
             },
             {
-                "characterRegex": "[0-9:. +-]",
-                "type": "font",
-                "name": "FONT_DIAVLO_MEDIUM_39",
-                "file": "fonts/Diavlo_MEDIUM_II_37.ttf"
+                "file": "fonts/Diavlo_LIGHT_II_37.ttf",
+                "name": "FONT_DIAVLO_LIGHT_15",
+                "type": "font"
             },
             {
-                "type": "font",
-                "name": "FONT_DIAVLO_MEDIUM_19",
-                "file": "fonts/Diavlo_MEDIUM_II_37.ttf"
-            },
-            {
-                "characterRegex": "[0-9:. +-]",
-                "type": "font",
-                "name": "FONT_DIAVLO_MEDIUM_29",
-                "file": "fonts/Diavlo_MEDIUM_II_37.ttf"
-            },
-            {
-                "type": "font",
-                "name": "FONT_DIAVLO_15",
-                "file": "fonts/Diavlo_BOOK_II_37.ttf"
+                "file": "images/menu_icon_bitwallet.png",
+                "menuIcon": true,
+                "name": "IMAGE_MENU_ICON",
+                "type": "png"
             }
         ]
+    },
+    "shortName": "BitWatcher",
+    "uuid": "0A477443-FB0A-4039-967F-7608276EEC45",
+    "versionCode": 3,
+    "versionLabel": "1.2",
+    "watchapp": {
+        "watchface": true
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -212,7 +212,7 @@ static void window_load(Window *window) {
 	text_time_layer = text_layer_create(GRect(7, 114, 144-7, 168-114));
 	text_layer_set_text_color(text_time_layer, GColorWhite);
 	text_layer_set_background_color(text_time_layer, GColorClear);
-	text_layer_set_font(text_time_layer, fonts_load_custom_font(resource_get_handle(RESOURCE_ID_FONT_DIAVLO_HEAVY_45)));
+	text_layer_set_font(text_time_layer, fonts_load_custom_font(resource_get_handle(RESOURCE_ID_FONT_DIAVLO_HEAVY_44)));
 	layer_add_child(window_layer, text_layer_get_layer(text_time_layer));
 	
 	tick_timer_service_subscribe(MINUTE_UNIT, handle_minute_tick);


### PR DESCRIPTION
Reduced RESOURCE_ID_FONT_DIAVLO_HEAVY size from 45 to 44. This should fix a bug that causes wide times (like 20:58, 10:55, etc.) to overflow off the side of the screen, which caused the minutes to be cut off, turned into 20:..., 10:..., etc.
